### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Ignore build artifacts
+*.o
+*.obj
+*.so
+*.dll
+*.dylib
+*.a
+aras
+build/
+*.exe
+*.out
+*.log


### PR DESCRIPTION
## Summary
- add `.gitignore` to ignore common build outputs like `*.o` and `build/`

## Testing
- `git status --short`