### PR TITLE
Refactor code into headers and source files

### DIFF
--- a/Blueprint.cpp
+++ b/Blueprint.cpp
@@ -1,0 +1,24 @@
+#include "Blueprint.h"
+#include "Project.h"
+#include "Tool.h"
+#include "Material.h"
+
+Blueprint::Blueprint(const std::string& name,
+                     const std::vector<std::pair<std::shared_ptr<Tool>, std::map<std::string, std::string>>>& requiredTools,
+                     const std::vector<std::pair<std::shared_ptr<Material>, double>>& requiredMaterials,
+                     const std::function<void(Project&)>& executionLogic)
+    : name_(name),
+      requiredTools_(requiredTools),
+      requiredMaterials_(requiredMaterials),
+      executionLogic_(executionLogic) {}
+
+std::string Blueprint::getName() const { return name_; }
+const std::vector<std::pair<std::shared_ptr<Tool>, std::map<std::string, std::string>>>& Blueprint::getRequiredTools() const {
+    return requiredTools_;
+}
+const std::vector<std::pair<std::shared_ptr<Material>, double>>& Blueprint::getRequiredMaterials() const {
+    return requiredMaterials_;
+}
+const std::function<void(Project&)>& Blueprint::getExecutionLogic() const {
+    return executionLogic_;
+}

--- a/Blueprint.h
+++ b/Blueprint.h
@@ -1,0 +1,30 @@
+#pragma once
+#include "Types.h"
+#include <string>
+#include <vector>
+#include <memory>
+#include <map>
+#include <functional>
+
+class Tool;
+class Material;
+class Project;
+
+class Blueprint : public IResource {
+public:
+    Blueprint(const std::string& name,
+              const std::vector<std::pair<std::shared_ptr<Tool>, std::map<std::string, std::string>>>& requiredTools,
+              const std::vector<std::pair<std::shared_ptr<Material>, double>>& requiredMaterials,
+              const std::function<void(Project&)>& executionLogic);
+
+    std::string getName() const override;
+    const std::vector<std::pair<std::shared_ptr<Tool>, std::map<std::string, std::string>>>& getRequiredTools() const;
+    const std::vector<std::pair<std::shared_ptr<Material>, double>>& getRequiredMaterials() const;
+    const std::function<void(Project&)>& getExecutionLogic() const;
+
+private:
+    std::string name_;
+    std::vector<std::pair<std::shared_ptr<Tool>, std::map<std::string, std::string>>> requiredTools_;
+    std::vector<std::pair<std::shared_ptr<Material>, double>> requiredMaterials_;
+    std::function<void(Project&)> executionLogic_;
+};

--- a/Material.cpp
+++ b/Material.cpp
@@ -1,0 +1,21 @@
+#include "Material.h"
+#include <stdexcept>
+
+Material::Material(const std::string& name, MaterialType type, double quantity)
+    : name_(name), type_(type), quantity_(quantity) {}
+
+std::string Material::getName() const { return name_; }
+MaterialType Material::getType() const { return type_; }
+double Material::getQuantity() const { return quantity_; }
+
+void Material::consume(double amount) {
+    if (quantity_ >= amount) {
+        quantity_ -= amount;
+    } else {
+        throw std::runtime_error("Not enough material available.");
+    }
+}
+
+void Material::replenish(double amount) {
+    quantity_ += amount;
+}

--- a/Material.h
+++ b/Material.h
@@ -1,0 +1,17 @@
+#pragma once
+#include "Types.h"
+#include <string>
+
+class Material : public IResource {
+public:
+    Material(const std::string& name, MaterialType type, double quantity);
+    std::string getName() const override;
+    MaterialType getType() const;
+    double getQuantity() const;
+    void consume(double amount);
+    void replenish(double amount);
+private:
+    std::string name_;
+    MaterialType type_;
+    double quantity_;
+};

--- a/Project.cpp
+++ b/Project.cpp
@@ -1,0 +1,83 @@
+#include "Project.h"
+#include "Blueprint.h"
+#include "Tool.h"
+#include "Material.h"
+#include <iostream>
+#include <stdexcept>
+
+Project::Project(const std::string& name,
+                 const std::shared_ptr<Blueprint>& blueprint,
+                 int priority)
+    : name_(name),
+      blueprint_(blueprint),
+      status_(ProjectStatus::IN_QUEUE),
+      priority_(priority) {}
+
+std::string Project::getName() const { return name_; }
+ProjectStatus Project::getStatus() const { return status_; }
+void Project::setStatus(ProjectStatus status) { status_ = status; }
+int Project::getPriority() const { return priority_; }
+const std::shared_ptr<Blueprint>& Project::getBlueprint() const { return blueprint_; }
+
+void Project::execute() {
+    if (!blueprint_) {
+        std::cerr << "[Project::execute] Error: Project "
+                  << name_ << " does not have a valid blueprint.\n";
+        status_ = ProjectStatus::FAILED;
+        return;
+    }
+
+    std::cout << "[Project::execute] Executing project: " << name_ << "\n";
+    status_ = ProjectStatus::ACQUIRING_RESOURCES;
+
+    for (const auto& toolPair : blueprint_->getRequiredTools()) {
+        if (!toolPair.first) {
+            std::cerr << "[Project::execute] Error: Invalid tool in blueprint for project "
+                      << name_ << "\n";
+            status_ = ProjectStatus::FAILED;
+            return;
+        }
+
+        std::cout << "    Acquiring tool: " << toolPair.first->getName() << "\n";
+        if (!toolPair.first->isOperational()) {
+            std::cerr << "[Project::execute] Error: Tool "
+                      << toolPair.first->getName() << " is not operational.\n";
+            status_ = ProjectStatus::FAILED;
+            return;
+        }
+
+        toolPair.first->adapt(toolPair.second);
+        acquiredTools_.push_back(toolPair.first);
+    }
+
+    for (const auto& materialPair : blueprint_->getRequiredMaterials()) {
+        if (!materialPair.first) {
+            std::cerr << "[Project::execute] Error: Invalid material in blueprint for project "
+                      << name_ << "\n";
+            status_ = ProjectStatus::FAILED;
+            return;
+        }
+
+        std::cout << "    Acquiring material: " << materialPair.first->getName()
+                  << " (Quantity: " << materialPair.second << ")\n";
+        try {
+            materialPair.first->consume(materialPair.second);
+            acquiredMaterials_.push_back(materialPair.first);
+        } catch (const std::runtime_error& error) {
+            std::cerr << "[Project::execute] Error: "
+                      << error.what()
+                      << " -> Project " << name_ << " failed.\n";
+            status_ = ProjectStatus::FAILED;
+            return;
+        }
+    }
+
+    status_ = ProjectStatus::IN_PROGRESS;
+    blueprint_->getExecutionLogic()(*this);
+
+    if (status_ != ProjectStatus::FAILED) {
+        status_ = ProjectStatus::COMPLETED;
+        std::cout << "[Project::execute] Project " << name_
+                  << " completed successfully.\n";
+    }
+}

--- a/Project.h
+++ b/Project.h
@@ -1,0 +1,31 @@
+#pragma once
+#include "Types.h"
+#include <string>
+#include <memory>
+#include <vector>
+
+class Blueprint;
+class Tool;
+class Material;
+
+class Project {
+public:
+    Project(const std::string& name,
+            const std::shared_ptr<Blueprint>& blueprint,
+            int priority = 0);
+
+    std::string getName() const;
+    ProjectStatus getStatus() const;
+    void setStatus(ProjectStatus status);
+    int getPriority() const;
+    const std::shared_ptr<Blueprint>& getBlueprint() const;
+    void execute();
+
+private:
+    std::string name_;
+    std::shared_ptr<Blueprint> blueprint_;
+    ProjectStatus status_;
+    int priority_;
+    std::vector<std::shared_ptr<Tool>> acquiredTools_;
+    std::vector<std::shared_ptr<Material>> acquiredMaterials_;
+};

--- a/ProjectManager.cpp
+++ b/ProjectManager.cpp
@@ -1,0 +1,65 @@
+#include "ProjectManager.h"
+#include <iostream>
+
+ProjectManager::ProjectManager() : stop_(false) {
+    worker_ = std::thread(&ProjectManager::processProjects, this);
+}
+
+ProjectManager::~ProjectManager() {
+    {
+        std::unique_lock<std::mutex> lock(mutex_);
+        stop_ = true;
+    }
+    cv_.notify_all();
+    if (worker_.joinable()) {
+        worker_.join();
+    }
+}
+
+void ProjectManager::addProject(const Project& project) {
+    {
+        std::unique_lock<std::mutex> lock(mutex_);
+        projectQueue_.push(project);
+    }
+    notifyListeners(ManagerEvent::PROJECT_ENQUEUED, project);
+    cv_.notify_one();
+}
+
+void ProjectManager::addListener(std::function<void(ManagerEvent, const Project&)> listener) {
+    listeners_.push_back(listener);
+}
+
+void ProjectManager::processProjects() {
+    while (true) {
+        Project currentProject("", nullptr);
+        {
+            std::unique_lock<std::mutex> lock(mutex_);
+            cv_.wait(lock, [this] {
+                return stop_ || !projectQueue_.empty();
+            });
+
+            if (stop_) {
+                break;
+            }
+
+            currentProject = projectQueue_.top();
+            projectQueue_.pop();
+        }
+
+        notifyListeners(ManagerEvent::PROJECT_STARTED, currentProject);
+
+        currentProject.execute();
+
+        if (currentProject.getStatus() == ProjectStatus::COMPLETED) {
+            notifyListeners(ManagerEvent::PROJECT_COMPLETED, currentProject);
+        } else if (currentProject.getStatus() == ProjectStatus::FAILED) {
+            notifyListeners(ManagerEvent::PROJECT_FAILED, currentProject);
+        }
+    }
+}
+
+void ProjectManager::notifyListeners(ManagerEvent event, const Project& p) {
+    for (auto& listener : listeners_) {
+        listener(event, p);
+    }
+}

--- a/ProjectManager.h
+++ b/ProjectManager.h
@@ -1,0 +1,36 @@
+#pragma once
+#include "Types.h"
+#include "Project.h"
+#include <queue>
+#include <vector>
+#include <functional>
+#include <thread>
+#include <mutex>
+#include <condition_variable>
+
+class ProjectManager {
+public:
+    ProjectManager();
+    ~ProjectManager();
+
+    void addProject(const Project& project);
+    void addListener(std::function<void(ManagerEvent, const Project&)> listener);
+
+private:
+    struct ProjectCompare {
+        bool operator()(const Project& a, const Project& b) {
+            return a.getPriority() < b.getPriority();
+        }
+    };
+
+    void processProjects();
+    void notifyListeners(ManagerEvent event, const Project& p = Project("None", nullptr));
+
+    std::priority_queue<Project, std::vector<Project>, ProjectCompare> projectQueue_;
+    std::vector<std::function<void(ManagerEvent, const Project&)>> listeners_;
+
+    std::thread worker_;
+    std::mutex mutex_;
+    std::condition_variable cv_;
+    bool stop_;
+};

--- a/Tool.cpp
+++ b/Tool.cpp
@@ -1,0 +1,18 @@
+#include "Tool.h"
+
+Tool::Tool(const std::string& name, ToolType type)
+    : name_(name), type_(type), operational_(true) {}
+
+std::string Tool::getName() const { return name_; }
+ToolType Tool::getType() const { return type_; }
+bool Tool::isOperational() const { return operational_; }
+void Tool::breakdown() { operational_ = false; }
+
+void Tool::adapt(const std::map<std::string, std::string>& parameters) {
+    std::cout << "[Tool::adapt] Adapting tool " << name_ << "...\n";
+    for (const auto& pair : parameters) {
+        std::cout << "    Setting parameter: " << pair.first
+                  << " to value: " << pair.second << "\n";
+    }
+    std::cout << "[Tool::adapt] Tool " << name_ << " adapted.\n";
+}

--- a/Tool.h
+++ b/Tool.h
@@ -1,0 +1,19 @@
+#pragma once
+#include "Types.h"
+#include <string>
+#include <map>
+#include <iostream>
+
+class Tool : public IResource, public IAdaptable {
+public:
+    Tool(const std::string& name, ToolType type);
+    std::string getName() const override;
+    ToolType getType() const;
+    bool isOperational() const;
+    void breakdown();
+    void adapt(const std::map<std::string, std::string>& parameters) override;
+private:
+    std::string name_;
+    ToolType type_;
+    bool operational_;
+};

--- a/Types.h
+++ b/Types.h
@@ -1,0 +1,52 @@
+#pragma once
+#include <string>
+#include <map>
+
+enum class ToolType {
+    NONE,
+    WELDER,
+    ASSEMBLER,
+    PAINTER,
+    SCANNER,
+    CALIBRATOR,
+    CUTTER,
+    PRINTER_3D,
+};
+
+enum class MaterialType {
+    NONE,
+    METAL,
+    PLASTIC,
+    COMPOSITE,
+    LIQUID,
+    GAS,
+    ELECTRONIC,
+};
+
+enum class ProjectStatus {
+    IN_QUEUE,
+    ACQUIRING_RESOURCES,
+    IN_PROGRESS,
+    PAUSED,
+    COMPLETED,
+    FAILED,
+};
+
+enum class ManagerEvent {
+    PROJECT_ENQUEUED,
+    PROJECT_STARTED,
+    PROJECT_COMPLETED,
+    PROJECT_FAILED
+};
+
+class IAdaptable {
+public:
+    virtual void adapt(const std::map<std::string, std::string>& parameters) = 0;
+    virtual ~IAdaptable() = default;
+};
+
+class IResource {
+public:
+    virtual std::string getName() const = 0;
+    virtual ~IResource() = default;
+};

--- a/main.cpp
+++ b/main.cpp
@@ -1,377 +1,29 @@
-#include <iostream>
-#include <vector>
-#include <map>
-#include <string>
+#include "Tool.h"
+#include "Material.h"
+#include "Blueprint.h"
+#include "Project.h"
+#include "ProjectManager.h"
 #include <memory>
-#include <functional>
-#include <algorithm>
-#include <stdexcept>
 #include <thread>
-#include <mutex>
-#include <queue>
-#include <condition_variable>
 #include <chrono>
-
-// Forward declarations
-class Tool;
-class Material;
-class Blueprint;
-class Project;
-class ProjectManager;
-
-// --- Enums ---
-
-// Enum for different tool types
-enum class ToolType {
-    NONE,
-    WELDER,
-    ASSEMBLER,
-    PAINTER,
-    SCANNER,
-    CALIBRATOR,
-    CUTTER,
-    PRINTER_3D,
-    // ... Add more as needed
-};
-
-// Enum for different material types
-enum class MaterialType {
-    NONE,
-    METAL,
-    PLASTIC,
-    COMPOSITE,
-    LIQUID,
-    GAS,
-    ELECTRONIC,
-    // ... Add more as needed
-};
-
-// Enum for project status
-enum class ProjectStatus {
-    IN_QUEUE,
-    ACQUIRING_RESOURCES,
-    IN_PROGRESS,
-    PAUSED,
-    COMPLETED,
-    FAILED,
-};
-
-// --- Interfaces ---
-
-// Interface for adaptable tools
-class IAdaptable {
-public:
-    virtual void adapt(const std::map<std::string, std::string>& parameters) = 0;
-    virtual ~IAdaptable() = default;
-};
-
-// Interface for a generic resource
-class IResource {
-public:
-    virtual std::string getName() const = 0;
-    virtual ~IResource() = default;
-};
-
-// --- Classes ---
-
-// Class representing a generic tool
-class Tool : public IResource, public IAdaptable {
-public:
-    Tool(const std::string& name, ToolType type) 
-        : name_(name), type_(type), operational_(true) {}
-
-    std::string getName() const override { return name_; }
-    ToolType getType() const { return type_; }
-    bool isOperational() const { return operational_; }
-    void breakdown() { operational_ = false; }
-    
-    void adapt(const std::map<std::string, std::string>& parameters) override {
-        std::cout << "[Tool::adapt] Adapting tool " << name_ << "...\n";
-        for (const auto& pair : parameters) {
-             std::cout << "    Setting parameter: " << pair.first 
-                       << " to value: " << pair.second << "\n";
-        }   
-        std::cout << "[Tool::adapt] Tool " << name_ << " adapted.\n";
-    }
-
-private:
-    std::string name_;
-    ToolType type_;
-    bool operational_;
-};
-
-// Class representing a generic material
-class Material : public IResource {
-public:
-    Material(const std::string& name, MaterialType type, double quantity) 
-        : name_(name), type_(type), quantity_(quantity) {}
-
-    std::string getName() const override { return name_; }
-    MaterialType getType() const { return type_; }
-    double getQuantity() const { return quantity_; }
-    
-    void consume(double amount) {
-        if (quantity_ >= amount) {
-            quantity_ -= amount;
-        } else {
-            throw std::runtime_error("Not enough material available.");
-        }
-    }
-
-    void replenish(double amount) {
-        quantity_ += amount;
-    }
-
-private:
-    std::string name_;
-    MaterialType type_;
-    double quantity_;
-};
-
-// Class representing a blueprint
-class Blueprint : public IResource {
-public:
-    Blueprint(const std::string& name,
-              const std::vector<std::pair<std::shared_ptr<Tool>, std::map<std::string, std::string>>>& requiredTools,
-              const std::vector<std::pair<std::shared_ptr<Material>, double>>& requiredMaterials,
-              const std::function<void(Project&)>& executionLogic)
-        : name_(name),
-          requiredTools_(requiredTools),
-          requiredMaterials_(requiredMaterials),
-          executionLogic_(executionLogic) {}
-
-    std::string getName() const override { return name_; }
-    const std::vector<std::pair<std::shared_ptr<Tool>, std::map<std::string, std::string>>>& getRequiredTools() const {
-        return requiredTools_;
-    }
-    const std::vector<std::pair<std::shared_ptr<Material>, double>>& getRequiredMaterials() const {
-        return requiredMaterials_;
-    }
-    const std::function<void(Project&)>& getExecutionLogic() const {
-        return executionLogic_;
-    }
-
-private:
-    std::string name_;
-    std::vector<std::pair<std::shared_ptr<Tool>, std::map<std::string, std::string>>> requiredTools_;
-    std::vector<std::pair<std::shared_ptr<Material>, double>> requiredMaterials_;
-    std::function<void(Project&)> executionLogic_;
-};
-
-// Class representing a project
-class Project {
-public:
-    Project(const std::string& name, 
-            const std::shared_ptr<Blueprint>& blueprint,
-            int priority = 0)
-        : name_(name),
-          blueprint_(blueprint),
-          status_(ProjectStatus::IN_QUEUE),
-          priority_(priority) {}
-
-    std::string getName() const { return name_; }
-    ProjectStatus getStatus() const { return status_; }
-    void setStatus(ProjectStatus status) { status_ = status; }
-
-    int getPriority() const { return priority_; }
-    const std::shared_ptr<Blueprint>& getBlueprint() const { return blueprint_; }
-    
-    void execute() {
-        if (!blueprint_) {
-            std::cerr << "[Project::execute] Error: Project " 
-                      << name_ << " does not have a valid blueprint.\n";
-            status_ = ProjectStatus::FAILED;
-            return;
-        }
-
-        std::cout << "[Project::execute] Executing project: " << name_ << "\n";
-        status_ = ProjectStatus::ACQUIRING_RESOURCES;
-
-        // Acquire necessary tools and adapt them
-        for (const auto& toolPair : blueprint_->getRequiredTools()) {
-            if (!toolPair.first) {
-                std::cerr << "[Project::execute] Error: Invalid tool in blueprint for project "
-                          << name_ << "\n";
-                status_ = ProjectStatus::FAILED;
-                return;
-            }
-
-            std::cout << "    Acquiring tool: " << toolPair.first->getName() << "\n";
-            if (!toolPair.first->isOperational()) {
-                std::cerr << "[Project::execute] Error: Tool " 
-                          << toolPair.first->getName() << " is not operational.\n";
-                status_ = ProjectStatus::FAILED;
-                return;
-            }
-
-            toolPair.first->adapt(toolPair.second);
-            acquiredTools_.push_back(toolPair.first);
-        }
-
-        // Acquire necessary materials
-        for (const auto& materialPair : blueprint_->getRequiredMaterials()) {
-            if (!materialPair.first) {
-                std::cerr << "[Project::execute] Error: Invalid material in blueprint for project "
-                          << name_ << "\n";
-                status_ = ProjectStatus::FAILED;
-                return;
-            }
-
-            std::cout << "    Acquiring material: " << materialPair.first->getName() 
-                      << " (Quantity: " << materialPair.second << ")\n";
-            try {
-                materialPair.first->consume(materialPair.second);
-                acquiredMaterials_.push_back(materialPair.first);
-            } catch (const std::runtime_error& error) {
-                std::cerr << "[Project::execute] Error: " 
-                          << error.what() 
-                          << " -> Project " << name_ << " failed.\n";
-                status_ = ProjectStatus::FAILED;
-                return;
-            }
-        }
-
-        status_ = ProjectStatus::IN_PROGRESS;
-
-        // Execute project logic
-        blueprint_->getExecutionLogic()(*this);
-
-        if (status_ != ProjectStatus::FAILED) {
-            status_ = ProjectStatus::COMPLETED;
-            std::cout << "[Project::execute] Project " << name_ 
-                      << " completed successfully.\n";
-        }
-    }
-
-private:
-    std::string name_;
-    std::shared_ptr<Blueprint> blueprint_;
-    ProjectStatus status_;
-    int priority_;
-    std::vector<std::shared_ptr<Tool>> acquiredTools_;
-    std::vector<std::shared_ptr<Material>> acquiredMaterials_;
-};
-
-// --- Project Manager with concurrency and event system ---
-
-// Simple event system for demonstration
-enum class ManagerEvent {
-    PROJECT_ENQUEUED,
-    PROJECT_STARTED,
-    PROJECT_COMPLETED,
-    PROJECT_FAILED
-};
-
-class ProjectManager {
-public:
-    ProjectManager() : stop_(false) {
-        // The worker thread continuously checks for available projects
-        worker_ = std::thread(&ProjectManager::processProjects, this);
-    }
-
-    ~ProjectManager() {
-        {
-            std::unique_lock<std::mutex> lock(mutex_);
-            stop_ = true;
-        }
-        cv_.notify_all();
-        if (worker_.joinable()) {
-            worker_.join();
-        }
-    }
-
-    void addProject(const Project& project) {
-        {
-            std::unique_lock<std::mutex> lock(mutex_);
-            projectQueue_.push(project);
-        }
-        notifyListeners(ManagerEvent::PROJECT_ENQUEUED);
-        cv_.notify_one();
-    }
-
-    void addListener(std::function<void(ManagerEvent, const Project&)> listener) {
-        listeners_.push_back(listener);
-    }
-
-private:
-    // A priority-comparator to ensure higher priority is processed first
-    struct ProjectCompare {
-        bool operator()(const Project& a, const Project& b) {
-            return a.getPriority() < b.getPriority();
-        }
-    };
-
-    void processProjects() {
-        while (true) {
-            Project currentProject("", nullptr);
-            {
-                std::unique_lock<std::mutex> lock(mutex_);
-                cv_.wait(lock, [this] {
-                    return stop_ || !projectQueue_.empty();
-                });
-
-                if (stop_) {
-                    break;
-                }
-
-                currentProject = projectQueue_.top();
-                projectQueue_.pop();
-            }
-
-            // Notify that we're starting a project
-            notifyListeners(ManagerEvent::PROJECT_STARTED, currentProject);
-
-            currentProject.execute();
-
-            // Check the final status of the project for notifications
-            if (currentProject.getStatus() == ProjectStatus::COMPLETED) {
-                notifyListeners(ManagerEvent::PROJECT_COMPLETED, currentProject);
-            } else if (currentProject.getStatus() == ProjectStatus::FAILED) {
-                notifyListeners(ManagerEvent::PROJECT_FAILED, currentProject);
-            }
-        }
-    }
-
-    void notifyListeners(ManagerEvent event, const Project& p = Project("None", nullptr)) {
-        for (auto& listener : listeners_) {
-            listener(event, p);
-        }
-    }
-
-    std::priority_queue<Project, std::vector<Project>, ProjectCompare> projectQueue_;
-    std::vector<std::function<void(ManagerEvent, const Project&)>> listeners_;
-
-    std::thread worker_;
-    std::mutex mutex_;
-    std::condition_variable cv_;
-    bool stop_;
-};
-
-// --- Main Function ---
+#include <iostream>
 
 int main() {
-    // Create some tools
     auto welder = std::make_shared<Tool>("Welder-01", ToolType::WELDER);
     auto assembler = std::make_shared<Tool>("Assembler-02", ToolType::ASSEMBLER);
     auto painter = std::make_shared<Tool>("Painter-03", ToolType::PAINTER);
-    auto printer3D = std::make_shared<Tool>("3D-Printer-04", ToolType::PRINTER_3D);
+    auto printer3D = std::make_shared<Tool>("Printer3D-04", ToolType::PRINTER_3D);
 
-    // Create some materials
-    auto metal = std::make_shared<Material>("Metal Sheet", MaterialType::METAL, 100.0);
-    auto plastic = std::make_shared<Material>("Plastic Roll", MaterialType::PLASTIC, 50.0);
-    auto paint = std::make_shared<Material>("Blue Paint", MaterialType::LIQUID, 20.0);
+    auto metal = std::make_shared<Material>("Metal", MaterialType::METAL, 100.0);
+    auto plastic = std::make_shared<Material>("Plastic", MaterialType::PLASTIC, 50.0);
+    auto paint = std::make_shared<Material>("Paint", MaterialType::LIQUID, 20.0);
 
-    // Define the execution logic for a welding/assembly project
     auto projectLogic = [&](Project& project) {
         std::cout << "[ExecutionLogic] " << project.getName() << " in progress...\n";
-
-        // Simulate some steps
         std::this_thread::sleep_for(std::chrono::milliseconds(500));
         std::cout << "    Welding and assembling...\n";
         std::this_thread::sleep_for(std::chrono::milliseconds(500));
         std::cout << "    Painting final product...\n";
-
-        // Random check: simulate a potential error
         if (project.getName() == "Project-Failable") {
             std::cerr << "[ExecutionLogic] Error: Unexpected glitch encountered.\n";
             project.setStatus(ProjectStatus::FAILED);
@@ -379,26 +31,20 @@ int main() {
         }
     };
 
-    // Define the execution logic for a 3D printing project
     auto printingLogic = [&](Project& project) {
         std::cout << "[ExecutionLogic] " << project.getName() << " in progress...\n";
         std::this_thread::sleep_for(std::chrono::milliseconds(300));
         std::cout << "    Configuring 3D Printer...\n";
-
-        // Simulate checking materials
         if (plastic->getQuantity() < 10.0) {
             std::cerr << "[ExecutionLogic] Error: Insufficient plastic for 3D printing.\n";
             project.setStatus(ProjectStatus::FAILED);
             return;
         }
-
         std::cout << "    Printing in progress...\n";
         std::this_thread::sleep_for(std::chrono::milliseconds(500));
         std::cout << "    3D printing completed.\n";
     };
 
-    // Create blueprints
-    // Blueprint 1: needs welder, assembler, painter, plus some metal, plastic, paint
     auto blueprint1 = std::make_shared<Blueprint>(
         "Blueprint-01",
         std::vector<std::pair<std::shared_ptr<Tool>, std::map<std::string, std::string>>>{
@@ -414,7 +60,6 @@ int main() {
         projectLogic
     );
 
-    // Blueprint that can fail
     auto blueprintFailable = std::make_shared<Blueprint>(
         "Blueprint-Failable",
         std::vector<std::pair<std::shared_ptr<Tool>, std::map<std::string, std::string>>>{
@@ -430,7 +75,6 @@ int main() {
         projectLogic
     );
 
-    // Blueprint 2: needs only the 3D printer, and some plastic
     auto blueprint2 = std::make_shared<Blueprint>(
         "Blueprint-02",
         std::vector<std::pair<std::shared_ptr<Tool>, std::map<std::string, std::string>>>{
@@ -442,15 +86,12 @@ int main() {
         printingLogic
     );
 
-    // Create projects with various priorities (higher means processed first)
     Project project1("Project-01", blueprint1, 1);
     Project projectFailable("Project-Failable", blueprintFailable, 2);
     Project project2("Project-02", blueprint2, 5);
 
-    // Create a project manager
     ProjectManager manager;
 
-    // Add a basic event listener
     manager.addListener(
         [&](ManagerEvent event, const Project& p) {
             switch (event) {
@@ -470,14 +111,10 @@ int main() {
         }
     );
 
-    // Enqueue projects
     manager.addProject(project1);
     manager.addProject(projectFailable);
     manager.addProject(project2);
 
-    // Let the program run a bit so the threads can process the projects
     std::this_thread::sleep_for(std::chrono::seconds(5));
-
-    // End of main, manager destructor will wait for worker thread to finish
     return 0;
 }


### PR DESCRIPTION
## Summary
- split class declarations into individual headers
- move implementations into matching cpp files
- shrink `main.cpp` to a driver that uses new classes

## Testing
- `g++ -std=c++17 -pthread -o aras main.cpp Tool.cpp Material.cpp Blueprint.cpp Project.cpp ProjectManager.cpp`
- `./aras > /tmp/output.txt && tail -n 20 /tmp/output.txt`