### PR TITLE
Add MIT license file and reference in README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Tomás Pellissari
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -100,5 +100,5 @@ Projects might represent experiments in computational biology, each requiring ce
 The concurrency layer can handle queueing of experiments with different priorities (urgent HPC tasks vs. background analyses).
  
 ## License
-Distributed under the MIT License. Use, modify, and distribute freely—with a dash of respect to the original conjurers.
+Distributed under the MIT License. See [LICENSE](LICENSE) for details. Use, modify, and distribute freely—with a dash of respect to the original conjurers.
 


### PR DESCRIPTION
## Summary
- add LICENSE file with standard MIT text
- mention LICENSE file in README

## Testing
- `g++ -std=c++17 main.cpp -o aras`