### PR TITLE
Use pointer for notifyListeners default argument

### DIFF
--- a/ProjectManager.h
+++ b/ProjectManager.h
@@ -24,7 +24,7 @@ private:
     };
 
     void processProjects();
-    void notifyListeners(ManagerEvent event, const Project& p = Project("None", nullptr));
+    void notifyListeners(ManagerEvent event, const Project* p = nullptr);
 
     std::priority_queue<Project, std::vector<Project>, ProjectCompare> projectQueue_;
     std::vector<std::function<void(ManagerEvent, const Project&)>> listeners_;


### PR DESCRIPTION
## Summary
- change notifyListeners() to accept a Project pointer
- update all call sites to pass a pointer

## Testing
- `g++ -std=c++17 -pthread *.cpp -o aras`